### PR TITLE
Update index.js fix the content type for xlsx

### DIFF
--- a/src/SpreadSheet/index.js
+++ b/src/SpreadSheet/index.js
@@ -63,7 +63,7 @@ class SpreadSheet {
       },
       xlsx: {
         bookType: 'xlsx',
-        header: 'application/application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        header: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
       },
       csv: {
         bookType: 'csv',


### PR DESCRIPTION
this cause a bug when open in my android phone because it has the wrong mimetype for xlsx
I forked and try to fix at line 66 and it worked.
just change application/application/vnd...  to application/vnd...